### PR TITLE
Update FsInteractiveService

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -1,13 +1,13 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.26)
+    FAKE (4.29.2)
     FunScript (1.1.94)
 GIT
   remote: https://github.com/ionide/ionide-helpers.git
      (9b047eed73f8a841bb6385cdd5d6d3a4fdc2510d)
       build: build.cmd
   remote: https://github.com/ionide/FsInteractiveService.git
-     (32fc5fe07fa3e89318a0c0c601f40f69aa7971c2)
+     (1868abbdb53ce3db9fd8a3714cc93501c1b5dda4)
       build: build.cmd CopyBinaries
 GITHUB
   remote: ionide/ionide-fsharp


### PR DESCRIPTION
We need a new release with the latest FsInteractiveService (including the fixes from: https://github.com/ionide/FsInteractiveService/pull/9)

I don't know how you manage the releases, but I think `paket restore` does not automatically rebuild the stuff from Git dependencies - so the only reliable way to get the latest version I found is to delete `paket-files` before running build....
